### PR TITLE
cleaning generated output from executable

### DIFF
--- a/.bin/ccompstan
+++ b/.bin/ccompstan
@@ -18,20 +18,14 @@ cd stanfrontend
 # ccomp doesn't compile down to object files, just asm
 ccomp -g3 -c $parent_dir/$name.stan && ccomp -c ${name}.s || exit 1
 
-# build libstan.so
+# build stanlib.o
 ccomp -g3 -c stanlib.c
-ld -shared stanlib.o -o libstan.so
-
-# remove staninput dependencies
-#ccomp -g3 -c stanlib.c
-#ccomp -g3 -c staninput.c
-#ld -shared stanlib.o staninput.o -o libstan.so
 
 # runtime is dependent on libstan, temporarily.
 ccomp -g3 -I${stan_dir} -c Runtime.c
 
 # compile the final binary
-ccomp -g3 -L${stan_dir} -Wl,-rpath=${stan_dir} -L../out/lib/compcert -lm -lstan ${name}.o Runtime.o -o runit
+ccomp -g3 -L${stan_dir} -L../out/lib/compcert -lm stanlib.o ${name}.o Runtime.o -o runit
 
 # tell the user what to do next
 echo "compiled! ./stanfrontend/runit INT"

--- a/.github/workflows/simple.yaml
+++ b/.github/workflows/simple.yaml
@@ -126,4 +126,4 @@ jobs:
       - name: Run compiled binary
         run: |
           echo $PWD
-          ./runit 100
+          ./stanfrontend/runit 100

--- a/.github/workflows/simple.yaml
+++ b/.github/workflows/simple.yaml
@@ -48,11 +48,12 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
-      - run: opam repo -y add coq-released https://coq.inria.fr/opam/released
+      - name: Add Coq repositories
+        run: opam repo -y add coq-released https://coq.inria.fr/opam/released
 
-      # dependencies for coq-proba
       # FIXME: really need to figure out how to fix `opam lock`
-      - run: |
+      - name: Install dependencies for coq-proba
+        run: |
           opam pin -y add                    num 1.3
           opam pin -y add                    coq 8.12.0
           opam pin -y add              coq-stdpp 1.4.0
@@ -62,12 +63,13 @@ jobs:
           opam pin -y add           coq-interval 4.0.0
           opam install -y coq-bignums
 
-      # dependencies for compcert
-      - run: |
+      - name: Install dependencies for CompCert
+        run: |
           opam pin -y add menhir 20210419
           opam install -y coq-coq2html
 
-      - run: |
+      - name: Configure and build ProbCompCert
+        run: |
           eval $(opam env);
 
           if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
@@ -81,25 +83,21 @@ jobs:
 
           make -j
 
-      # Simplified way to build a binary without .bin/ccompstan
-      - run: |
+      - name: Build stanfrontend/tests/simple/simple.stan
+        run: |
           eval $(opam env);
 
           # install bin and lib outputs to ./out
           #make -j install
           sudo make -j install
-          #export LIBCCOMP_INSTALL=$PWD/out/lib
 
           cd stanfrontend
-          #echo "LIBCCOMP_INSTALL = $LIBCCOMP_INSTALL"
 
           # ccomp doesn't compile down to object files, just asm
           #export CCOMP="../out/bin/ccomp -L$LIBCCOMP_INSTALL"
           export CCOMP="ccomp -L. -I."
 
           $CCOMP -c stanlib.c
-          #ld -L$LIBCCOMP_INSTALL -shared stanlib.o -o libstan.so --verbose
-          #ld -shared stanlib.o -o libstan.so
           echo [DONE] stanlib.o
 
           $CCOMP -c tests/simple/simple.stan && $CCOMP -c simple.s
@@ -109,9 +107,11 @@ jobs:
           echo [DONE] Runtime.o
 
           $CCOMP stanlib.o simple.o Runtime.o -lm -o runit
+
           # tell the user what to do next
           echo [DONE] compiled! run: ./stanfrontend/runit INT
 
+          # ensure that binary has correct runtime execution
           export RUNIT_OUTPUT=\"$(./runit)\"
 
           if [[ -z "$(echo "$(./runit)" | grep error)" ]]; then
@@ -123,8 +123,7 @@ jobs:
             exit 1
           fi
 
-
-      # attempt to run!
-      - run: |
+      - name: Run compiled binary
+        run: |
           echo $PWD
           ./runit 100

--- a/.github/workflows/simple.yaml
+++ b/.github/workflows/simple.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        # - macos-latest # requires changing x86_64-linux, below, to x86_64-macosx
+          - macos-latest # requires changing x86_64-linux, below, to x86_64-macosx
           - ubuntu-latest
         ocaml-compiler:
           - 4.10.2
@@ -69,8 +69,16 @@ jobs:
 
       - run: |
           eval $(opam env);
-          #./configure -prefix ./out -clightgen x86_64-linux
-          ./configure -clightgen x86_64-linux
+
+          if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+              echo "configuring for x86_64-macosx"
+              ./configure -clightgen x86_64-macosx
+          else
+              echo "configuring for x86_64-linux"
+              ./configure -clightgen x86_64-linux
+              # ./configure -prefix ./out -clightgen x86_64-linux
+          fi
+
           make -j
 
       # Simplified way to build a binary without .bin/ccompstan

--- a/.github/workflows/simple.yaml
+++ b/.github/workflows/simple.yaml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - pcp
+      - feature/polish-runit
   pull_request:
     branches:
       - pcp
@@ -90,8 +91,8 @@ jobs:
 
           $CCOMP -c stanlib.c
           #ld -L$LIBCCOMP_INSTALL -shared stanlib.o -o libstan.so --verbose
-          ld -shared stanlib.o -o libstan.so
-          echo [DONE] libstan.so
+          #ld -shared stanlib.o -o libstan.so
+          echo [DONE] stanlib.o
 
           $CCOMP -c tests/simple/simple.stan && $CCOMP -c simple.s
           echo [DONE] simple.o
@@ -99,15 +100,19 @@ jobs:
           $CCOMP -c Runtime.c
           echo [DONE] Runtime.o
 
-          $CCOMP -Wl,-rpath=. simple.o Runtime.o -lstan -lm -o runit
+          $CCOMP stanlib.o simple.o Runtime.o -lm -o runit
           # tell the user what to do next
           echo [DONE] compiled! run: ./stanfrontend/runit INT
 
           export RUNIT_OUTPUT=\"$(./runit)\"
 
           if [[ -z "$(echo "$(./runit)" | grep error)" ]]; then
-            echo [SUCCESS] ./runit runs with output:
-            echo $RUNIT_OUTPUT
+              echo [DONE] ./runit compiled with output:
+              echo $RUNIT_OUTPUT
+
+              # we make have to change this as the CLI changes
+              echo 'Running: ./runit 100'
+              ./runit 100
           else
             echo [ERROR] ./runit fails at runtime with message:
             echo $RUNIT_OUTPUT

--- a/.github/workflows/simple.yaml
+++ b/.github/workflows/simple.yaml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - pcp
-      - feature/polish-runit
   pull_request:
     branches:
       - pcp
@@ -31,8 +30,10 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest # requires changing x86_64-linux, below, to x86_64-macosx
           - ubuntu-latest
+          # - macos-latest
+          # FIXME: errors when compiling stanlib.c. See:
+          # https://github.com/stites/ProbCompCert/runs/4754816523?check_suite_focus=true#step:8:75
         ocaml-compiler:
           - 4.10.2
 

--- a/.github/workflows/simple.yaml
+++ b/.github/workflows/simple.yaml
@@ -115,12 +115,8 @@ jobs:
           export RUNIT_OUTPUT=\"$(./runit)\"
 
           if [[ -z "$(echo "$(./runit)" | grep error)" ]]; then
-              echo [DONE] ./runit compiled with output:
+              echo [SUCCESS] ./runit compiled with output:
               echo $RUNIT_OUTPUT
-
-              # we make have to change this as the CLI changes
-              echo 'Running: ./runit 100'
-              ./runit 100
           else
             echo [ERROR] ./runit fails at runtime with message:
             echo $RUNIT_OUTPUT
@@ -128,3 +124,7 @@ jobs:
           fi
 
 
+      # attempt to run!
+      - run: |
+          echo $PWD
+          ./runit 100

--- a/stanfrontend/Runtime.c
+++ b/stanfrontend/Runtime.c
@@ -53,15 +53,17 @@ int main(int argc, char* argv[]) {
 
     if (u <= lp_candidate - lp_parameters) {
       set_state(newpi);
-      printf("setting state in iteration %d: ", i+1); // 1-index iterations
-      print_state(&state);
+      printf("setting state in iteration %d. target log_prob: %f\n", i+1, lp_candidate); // 1-index iterations
+      // printf("setting state in iteration %d: ", i+1); // 1-index iterations
+      // print_state(&state);
     }
 
     generated_quantities();
   }
 
-  printf("\t...completed execution!\n\nSummary:\n\t");
-  print_state(&state);
+  printf("\n...completed execution!");
+  // printf("\n\nSummary:\n\t");
+  // print_state(&state);
   printf("\n");
   return 0;
   


### PR DESCRIPTION
In addition, CI will now run the compiled simple.stan so that we can see the expected output. The expected output will look like https://github.com/stites/ProbCompCert/runs/4755686639?check_suite_focus=true#step:9:1 

Note that macos-latest has been disabled in CI due to the error found in https://github.com/stites/ProbCompCert/runs/4754816523?check_suite_focus=true#step:8:75 . I don't have access to a mac (and github won't let you ssh into the images), So this will have to be solved by someone else.